### PR TITLE
Feat: Add precise frame navigation and controls

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+*.css text eol=lf
+*.sh text eol=lf
+*.bat text eol=crlf
+*.png binary
+*.ico binary


### PR DESCRIPTION
## Feature: Precise Frame Navigation and Control

**Description:**

This pull request addresses user feedback regarding the difficulty of selecting precise start/end frames using only the slider, especially for longer videos. It introduces several enhancements to provide more granular control over video navigation and range definition.

**Key Changes Implemented:**

*   **Frame-by-Frame Navigation:**
    *   Added "< Frame" and "Frame >" buttons below the video player.
    *   Implemented keyboard shortcuts:
        *   **Left Arrow:** Step back one frame.
        *   **Right Arrow:** Step forward one frame.
    *   Implemented `step_frame()` logic in `VideoEditor`.

*   **Time-Based Jumping:**
    *   Implemented keyboard shortcuts:
        *   **Shift + Left Arrow:** Jump back one second (calculates frames based on video FPS).
        *   **Shift + Right Arrow:** Jump forward one second.
    *   Implemented `jump_frames()` logic in `VideoEditor`.

*   **Direct Frame Input:**
    *   Added a "Go to Frame:" input field next to the frame stepping buttons.
    *   Users can type a frame number and press Enter to jump directly to that frame.
    *   Implemented `goto_frame()` logic in `VideoEditor` and connected the input field's `returnPressed` signal in `VideoCropper`.

*   **Persistent Frame/Timecode Display:**
    *   Added a central label below the slider that continuously displays the current frame number and the corresponding timecode (e.g., `Frame: 1234 / 15000 (00:02:03.45 / 00:05:00.00)`).
    *   This label updates during scrubbing, playback, stepping, and jumping.
    *   Implemented `update_current_frame_label()` in `VideoCropper` and helper `_format_timecode()`. Logic integrated into `VideoEditor.update_frame_display()`.
    *   Removed the old, less informative "Clip Length / Video Length" label.

*   **UI Layout Adjustments:**
    *   Rearranged controls below the slider to accommodate the new frame controls and display label.
    *   Updated the keybindings help text label at the top right to reflect the new shortcuts.

*   **Refined Range Nudging:**
    *   Modified the "Nudge Start Frame" logic (**A**/**S** keys) to preserve the *duration* of the selected range by adjusting the end frame accordingly, rather than just shifting the start point. End frame nudging (**Q**/**W** keys) remains unchanged (adjusts duration).

**Impact:**

These changes provide users with significantly improved precision when working with videos. They can now easily:
*   Navigate frame-by-frame for exact positioning.
*   Jump directly to specific frames or make larger time-based jumps.
*   Always see their precise current location within the video.
*   Verify ranges more effectively before exporting or sending to Gemini.

This makes the tool much more suitable for preparing datasets from longer videos where exact frame accuracy is critical.